### PR TITLE
fix subgraph query + add custom subgraph url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ yarn-error.log*
 
 \*.tsbuildinfo
 next-env.d.ts
+
+# vim
+
+*.swp

--- a/src/hooks/useCommitments.ts
+++ b/src/hooks/useCommitments.ts
@@ -13,7 +13,7 @@ export function useCommitments() {
     query: CommitmentsQueryDocument,
     variables: {
       lastLeafIndex: -1,
-      contractAddress
+      contractAddress: contractAddress.toLowerCase()
     },
     requestPolicy: 'cache-and-network'
   });

--- a/src/hooks/useExistingCommitments.ts
+++ b/src/hooks/useExistingCommitments.ts
@@ -23,11 +23,11 @@ export function useExistingCommitments() {
       leafIndexToIndex[Number(commitmentData.leafIndex)] =
         existingCommitments.length;
       existingCommitments.push({
-        nullifier: poseidon([
+        nullifier: BigNumber.from(poseidon([
           secret,
           1,
           commitmentData.leafIndex
-        ] as BigNumberish[]).toString(),
+        ] as BigNumberish[]).toString()).toHexString(),
         ...commitmentData
       });
     }

--- a/src/hooks/useSubsetDataByNullifier.ts
+++ b/src/hooks/useSubsetDataByNullifier.ts
@@ -18,9 +18,9 @@ export function useSubsetDataByNullifier() {
     useQuery<SubsetDataByNullifierQuery>({
       query: SubsetDataByNullifierQueryDocument,
       variables: {
-        contractAddress,
-        nullifier: recentWithdrawal.nullifier,
-        subsetRoot: recentWithdrawal.subsetRoot
+        contractAddress: contractAddress.toLowerCase(),
+        nullifier: recentWithdrawal.nullifier.toLowerCase(),
+        subsetRoot: recentWithdrawal.subsetRoot.toLowerCase()
       }
       // requestPolicy: 'cache-and-network'
     });

--- a/src/hooks/useSubsetRoots.ts
+++ b/src/hooks/useSubsetRoots.ts
@@ -17,7 +17,7 @@ export function useSubsetRoots() {
       query: SubsetRootsByTimestampDocument,
       variables: {
         timestamp: 0,
-        contractAddress
+        contractAddress: contractAddress.toLowerCase()
       },
       requestPolicy: 'cache-and-network'
     });

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,7 @@ import { createClient, Provider as UrqlProvider } from 'urql';
 
 const urqlClient = createClient({
   // url: 'https://api.thegraph.com/subgraphs/name/ameensol/privacy-pools'
-  url: 'https://api.thegraph.com/subgraphs/name/schmidsi/pools-graph'
+  url: 'https://api.thegraph.com/subgraphs/name/dan13ram/pools-optimism-goerli'
 });
 
 function App({ Component, pageProps }: AppProps) {

--- a/src/pages/withdraw.tsx
+++ b/src/pages/withdraw.tsx
@@ -250,6 +250,7 @@ function Page() {
       isLoading ||
       existingCommitments.length === 0
   );
+
   const isGenerateProofDisabled = Boolean(
     isNullifierInvalid ||
       isRecipientInvalid ||
@@ -261,8 +262,7 @@ function Page() {
       !nullifier ||
       !recipient ||
       !relayer ||
-      !fee ||
-      isFeeInvalid
+      !fee
   );
 
   const generateZkProof = async () => {

--- a/src/query/commitments.ts
+++ b/src/query/commitments.ts
@@ -8,8 +8,7 @@ export const CommitmentsQueryDocument = /* GraphQL */ `
   query Commitments($lastLeafIndex: Int, $contractAddress: String!) {
     commitments(
       orderBy: leafIndex
-      contractAddress: $contractAddress
-      where: { leafIndex_gt: $lastLeafIndex }
+      where: { contractAddress: $contractAddress, leafIndex_gt: $lastLeafIndex }
     ) {
       leafIndex
       commitment


### PR DESCRIPTION
Two fixes:
- the deployed subgraph was indexing only the "0.01 ETH" pool so i redeployed with a fix (https://github.com/ameensol/pools-graph/pull/2)
- querying with contractAddress.toLowerCase()


Tested deposit + withdraw flows. 
Works great for the "0.001 ETH" pool 🥂 but fails at generate proof step for "0.01 ETH" pool.
Not sure what exactly is the issue.

Here is the error log: 
next-dev.js?3515:20 ERROR:  4 
next-dev.js?3515:20 Error: Error: Assert Failed. 
    at eval (witness_calculator.js?41c2:433:1)
    at Array.forEach (<anonymous>)
    at WitnessCalculatorCircom2._doCalculateWitness (witness_calculator.js?41c2:418:1)
    at WitnessCalculatorCircom2.calculateWTNSBin (witness_calculator.js?41c2:463:1)
    at wtnsCalculate (wtns_calculate.js?6987:45:1)
    at async Module.groth16FullProve (groth16_fullprove.js?b7e5:31:1)
    at async generateZkProof (withdraw.tsx?a9f4:300:40)
    