### PR TITLE
Connect Note Wallet to Deposit and withdraw pages.

### DIFF
--- a/src/pages/deposit.tsx
+++ b/src/pages/deposit.tsx
@@ -337,9 +337,7 @@ function Page() {
             <Stack>
               <Center h="100%" pt={4} px={4}>
                 {commitment.eq(0) ? (
-                  <Text color="white" fontSize="lg" fontWeight="bold">
-                    Connect your Note Wallet
-                  </Text>
+                  <NoteWalletConnectButton />
                 ) : (
                   <Button
                     bg="gray.100"

--- a/src/pages/withdraw.tsx
+++ b/src/pages/withdraw.tsx
@@ -54,7 +54,7 @@ import {
   useWaitForTransaction
 } from 'wagmi';
 import { useAtom } from 'jotai';
-import { DappLayout, SubsetMakerButton } from '../components';
+import { DappLayout, NoteWalletConnectButton, SubsetMakerButton } from '../components';
 import {
   assetAtom,
   denominationAtom,
@@ -864,9 +864,7 @@ function Page() {
                 p={4}
               >
                 {commitment.eq(0) ? (
-                  <Text color="white" fontSize="lg" fontWeight="bold">
-                    Connect your Note Wallet
-                  </Text>
+                  <NoteWalletConnectButton />
                 ) : (
                   <>
                     <SubsetMakerButton />


### PR DESCRIPTION
# Description

This was also super confusing during testing. I couldn't connect to create a new note wallet in the deposit and withdraw pages so I'm adding the button here.


![Peek 2023-03-04 15-15](https://user-images.githubusercontent.com/1673206/222926871-fd628984-a7f8-42a6-bbe5-5f7b5c5260da.gif)
