### PR TITLE
Fix Explorer Subset Data viewing.

### DIFF
--- a/src/hooks/useExplorerData.ts
+++ b/src/hooks/useExplorerData.ts
@@ -8,6 +8,21 @@ import {
   useSubsetDataByNullifier
 } from '../hooks';
 
+export interface ExplorerDataI {
+  accessList: AccessList;
+  includedDeposits: Commitment[];
+  excludedDeposits: Commitment[];
+}
+
+const defaultExplorerData: ExplorerDataI = {
+  accessList: AccessList.fullEmpty({
+    accessType: 'blocklist',
+    subsetLength: 0
+  }),
+  includedDeposits: [],
+  excludedDeposits: []
+};
+
 export function useExplorerData() {
   const { commitments } = useCommitments();
   const [recentWithdrawal] = useAtom(recentWithdrawalAtom);
@@ -18,52 +33,41 @@ export function useExplorerData() {
 
   const { nullifier, subsetRoot } = debouncedRecentWithdrawal;
   const { accessType, bitLength, subsetData: data } = subsetMetadata;
-
-  if (
-    !nullifier ||
-    !subsetRoot ||
-    !debouncedCommitments.length ||
-    !accessType ||
-    isNaN(bitLength) ||
-    data.length === 0
-  ) {
-    return {
-      accessList: AccessList.fullEmpty({
-        accessType: 'blocklist',
-        subsetLength: 0
-      }),
-      includedDeposits: [],
-      excludedDeposits: []
-    };
-  }
-
-  const accessList = new AccessList({
-    accessType,
-    bytesData: { bitLength, data }
-  });
-  let includedDeposits: Commitment[];
-  let excludedDeposits: Commitment[];
-  if (commitments.length >= accessList.length) {
-    let start = 0;
-    const end = accessList.length;
-    if (end > 30) {
-      start = end - 30;
+  
+  const [explorerData, setExplorerData] = useState<ExplorerDataI>(defaultExplorerData);
+  
+  useEffect(() => {
+    const accessList = new AccessList({
+      accessType,
+      bytesData: { bitLength, data }
+    });
+    let includedDeposits: Commitment[];
+    let excludedDeposits: Commitment[];
+    if (commitments.length >= accessList.length) {
+      let start = 0;
+      const end = accessList.length;
+      if (end > 30) {
+        start = end - 30;
+      }
+      const c = commitments.slice(start, end);
+      includedDeposits = c.filter(
+        ({ leafIndex }) => accessList.subsetData[Number(leafIndex)] === 0
+      );
+      excludedDeposits = c.filter(
+        ({ leafIndex }) => accessList.subsetData[Number(leafIndex)] === 1
+      );
+    } else {
+      includedDeposits = [];
+      excludedDeposits = [];
     }
-    const c = commitments.slice(start, end);
-    includedDeposits = c.filter(
-      ({ leafIndex }) => accessList.subsetData[Number(leafIndex)] === 0
-    );
-    excludedDeposits = c.filter(
-      ({ leafIndex }) => accessList.subsetData[Number(leafIndex)] === 1
-    );
-  } else {
-    includedDeposits = [];
-    excludedDeposits = [];
-  }
+    setExplorerData({
+      accessList,
+      includedDeposits,
+      excludedDeposits
+    });
 
-  return {
-    accessList,
-    includedDeposits,
-    excludedDeposits
-  };
+  }, [nullifier, subsetRoot, debouncedCommitments, accessType, bitLength, data]);
+
+  return explorerData;
+
 }

--- a/src/hooks/useExplorerData.ts
+++ b/src/hooks/useExplorerData.ts
@@ -41,9 +41,7 @@ export function useExplorerData() {
       !nullifier ||
       !subsetRoot ||
       !debouncedCommitments.length ||
-      !accessType ||
-      isNaN(bitLength) ||
-      data.length === 0
+      !accessType
     ) {
       return setExplorerData(defaultExplorerData);
     }
@@ -53,13 +51,13 @@ export function useExplorerData() {
     });
     let includedDeposits: Commitment[];
     let excludedDeposits: Commitment[];
-    if (commitments.length >= accessList.length) {
+    if (debouncedCommitments.length >= accessList.length) {
       let start = 0;
       const end = accessList.length;
       if (end > 30) {
         start = end - 30;
       }
-      const c = commitments.slice(start, end);
+      const c = debouncedCommitments.slice(start, end);
       includedDeposits = c.filter(
         ({ leafIndex }) => accessList.subsetData[Number(leafIndex)] === 0
       );
@@ -70,6 +68,7 @@ export function useExplorerData() {
       includedDeposits = [];
       excludedDeposits = [];
     }
+
     setExplorerData({
       accessList,
       includedDeposits,

--- a/src/hooks/useExplorerData.ts
+++ b/src/hooks/useExplorerData.ts
@@ -37,6 +37,16 @@ export function useExplorerData() {
   const [explorerData, setExplorerData] = useState<ExplorerDataI>(defaultExplorerData);
   
   useEffect(() => {
+    if (
+      !nullifier ||
+      !subsetRoot ||
+      !debouncedCommitments.length ||
+      !accessType ||
+      isNaN(bitLength) ||
+      data.length === 0
+    ) {
+      return setExplorerData(defaultExplorerData);
+    }
     const accessList = new AccessList({
       accessType,
       bytesData: { bitLength, data }

--- a/src/hooks/useSubsetDataByNullifier.ts
+++ b/src/hooks/useSubsetDataByNullifier.ts
@@ -24,6 +24,15 @@ export function useSubsetDataByNullifier() {
       }
       // requestPolicy: 'cache-and-network'
     });
+    
+  useEffect(() => {
+    executeSubsetDatasQuery({
+      contractAddress: contractAddress.toLowerCase(),
+      nullifier: recentWithdrawal.nullifier.toLowerCase(),
+      subsetRoot: recentWithdrawal.subsetRoot.toLowerCase()
+    });
+
+  }, [recentWithdrawal, contractAddress]);
 
   useEffect(() => {
     if (

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -305,7 +305,7 @@ function Page() {
           </Stack>
         </Container>
 
-        {accessList.length > 0 && (
+        { accessList.length >= 0  && (
           <Container centerContent minW="216px" maxW="960px" mb={40}>
             <Stack w="full">
               <Stack
@@ -524,59 +524,60 @@ function Page() {
                         </Text>
                       </HStack>
 
-                      <VStack
-                        w="full"
-                        minH="360px"
-                        overflowY="auto"
-                        bg="gray.50"
-                        py={4}
-                        gap={1}
-                      >
-                        {includedDeposits
-                          .slice(
-                            includedDeposits.length < 30
-                              ? 0
-                              : includedDeposits.length - 30
-                          )
-                          .map(({ commitment, sender, leafIndex }, index) => (
-                            <HStack
-                              key={`included-${leafIndex}`}
-                              justify="center"
-                              w="full"
-                              borderTop={index ? 'solid 1px #BEE3F8' : 'none'}
-                              pt={4}
-                            >
-                              <HStack w="33%" justify="center">
-                                <Text>{leafIndex.toString()}</Text>
-                              </HStack>
+                      { includedDeposits.length > 0 ?
+                        <VStack
+                          w="full"
+                          minH="360px"
+                          overflowY="auto"
+                          bg="gray.50"
+                          py={4}
+                          gap={1}
+                        >
+                          { includedDeposits
+                            .slice(
+                              includedDeposits.length < 30
+                                ? 0
+                                : includedDeposits.length - 30
+                            )
+                            .map(({ commitment, sender, leafIndex }, index) => (
+                              <HStack
+                                key={`included-${leafIndex}`}
+                                justify="center"
+                                w="full"
+                                borderTop={index ? 'solid 1px #BEE3F8' : 'none'}
+                                pt={4}
+                              >
+                                <HStack w="33%" justify="center">
+                                  <Text>{leafIndex.toString()}</Text>
+                                </HStack>
 
-                              <HStack w="33%" justify="flex-start">
-                                <Link
-                                  as={NextLink}
-                                  {...growShrinkProps}
-                                  href={`${chain?.blockExplorers?.default.url}/address/${sender}`}
-                                  isExternal
-                                >
-                                  <Text
-                                    key={`sender-${leafIndex}`}
-                                    color="blue.700"
-                                    fontSize="sm"
-                                    textAlign="left"
-                                    wordBreak="break-all"
+                                <HStack w="33%" justify="flex-start">
+                                  <Link
+                                    as={NextLink}
                                     {...growShrinkProps}
+                                    href={`${chain?.blockExplorers?.default.url}/address/${sender}`}
+                                    isExternal
                                   >
-                                    {pinchString(sender.toString(), 5)}{' '}
-                                    <ExternalLinkIcon />
-                                  </Text>
-                                </Link>
-                              </HStack>
+                                    <Text
+                                      key={`sender-${leafIndex}`}
+                                      color="blue.700"
+                                      fontSize="sm"
+                                      textAlign="left"
+                                      wordBreak="break-all"
+                                      {...growShrinkProps}
+                                    >
+                                      {pinchString(sender.toString(), 5)}{' '}
+                                      <ExternalLinkIcon />
+                                    </Text>
+                                  </Link>
+                                </HStack>
 
-                              <HStack w="33%" justify="flex-start">
-                                <Text>{pinchString(commitment, 6)}</Text>
+                                <HStack w="33%" justify="flex-start">
+                                  <Text>{pinchString(commitment, 6)}</Text>
+                                </HStack>
                               </HStack>
-                            </HStack>
-                          ))}
-                      </VStack>
+                            ))}
+                        </VStack> : "" }
                     </>
                   )}
 


### PR DESCRIPTION
# Description

Wraps state updates in useEffect to help eliminate some random state bugs. Also, fixes the UI in an edge case where the subsetData query returns an empty subsetData.

# Open Issues

- When the wallet is not connected, most of the withdraws return "Subset invalid" since the expected and computed subset roots don't match. Is this expected behavior?

# Testing

1. Connect wallet.
2. Go to Explorer page.
3.  Click on Inspect, you should see the subset data dropdown for every withdrawal.
4. Explicitly check 0x45e...b6e2f and 0xd87...63e09 in the withdraw lists. One should have an invalid subset and the other doesn't have a returned subset data. You should be able to inspect both withdrawals. (See video below)

![Peek 2023-03-07 17-01](https://user-images.githubusercontent.com/1673206/223563428-4496f499-d763-4419-9070-01f89d051aa7.gif)
