### PR TITLE
Fix: able to scroll through all the commitments

### DIFF
--- a/src/components/SubsetMaker/SubsetMaker.tsx
+++ b/src/components/SubsetMaker/SubsetMaker.tsx
@@ -143,10 +143,7 @@ export function SubsetMaker() {
           <Container p={0} centerContent overflowY="auto" maxH="50vh">
             {!commitment.eq(0) &&
               commitments.length > 0 &&
-              (commitments.length > 30
-                ? commitments.slice(commitments.length - 30)
-                : commitments
-              ).map((commitmentData, i) => {
+              commitments.map((commitmentData, i) => {
                 return (
                   <HStack key={`row-${i}-${commitmentData.leafIndex}`} w="full">
                     <Container centerContent p={0} w="10%">


### PR DESCRIPTION
I think this is what you meant in your tweet: https://twitter.com/ameensol/status/1633656479973769216

Be able to scroll back to commitment 0, not restricted to the most recent 30